### PR TITLE
Add manual issue triage workflow

### DIFF
--- a/.github/actions/claude-issue-triage-action/action.yml
+++ b/.github/actions/claude-issue-triage-action/action.yml
@@ -12,6 +12,9 @@ inputs:
   github_token:
     description: "GitHub token with repo and issues permissions"
     required: true
+  issue_number:
+    description: "Issue number to triage (optional - defaults to event issue number)"
+    required: false
 
 runs:
   using: "composite"
@@ -32,7 +35,7 @@ runs:
 
         Issue Information:
         - REPO: ${{ github.repository }}
-        - ISSUE_NUMBER: ${{ github.event.issue.number }}
+        - ISSUE_NUMBER: ${{ inputs.issue_number || github.event.issue.number }}
 
         TASK OVERVIEW:
 

--- a/.github/workflows/claude-issue-triage-manual.yml
+++ b/.github/workflows/claude-issue-triage-manual.yml
@@ -1,0 +1,46 @@
+name: Claude Issue Triage Manual
+description: "Manually triage GitHub issues using Claude Code"
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_numbers:
+        description: 'Comma-separated list of issue numbers to triage (e.g., 123,456,789)'
+        required: true
+        type: string
+
+jobs:
+  parse-issues:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Parse issue numbers
+        id: set-matrix
+        run: |
+          # Remove spaces and convert to JSON array
+          CLEANED=$(echo "${{ github.event.inputs.issue_numbers }}" | tr -d ' ')
+          IFS=',' read -ra ISSUES <<< "$CLEANED"
+          MATRIX_JSON=$(printf '%s\n' "${ISSUES[@]}" | jq -R . | jq -s -c '{issue: .}')
+          echo "matrix=$MATRIX_JSON" >> $GITHUB_OUTPUT
+
+  triage-issue:
+    needs: parse-issues
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    strategy:
+      matrix: ${{ fromJson(needs.parse-issues.outputs.matrix) }}
+      max-parallel: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+
+      - name: Run Claude Issue Triage
+        uses: ./.github/actions/claude-issue-triage-action
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_number: ${{ matrix.issue }}


### PR DESCRIPTION
- Add optional issue_number parameter to Claude Issue Triage Action
- Create manual workflow that accepts comma-separated issue numbers
- Maintains backward compatibility with existing issue event workflow

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

```markdown
### What change is being made?
Add a manual issue triage workflow leveraging Claude Code and integrate new GitHub Actions for automatic and manual issue triage.

### Why are these changes being made?
This change introduces a new set of workflows intended to streamline the issue triaging process on GitHub by utilizing Claude Code to automatically label GitHub issues. This method enhances efficiency and maintains consistency in issue management without requiring manual intervention. The addition of manual inputs also ensures flexibility where automatic triage may not suffice. This approach capitalizes on Claude Code's capabilities to analyze and categorize issues accurately using the available GitHub tools.
```

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->